### PR TITLE
fix(S3): Replace static s3 paths with constants from hsg-shell config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 build/*
-.existdb.json
+.*
+!.gitignore
 cache
 modules/aws_config.xqm
-.DS_Store
 expath-pkg.xml
 repo.xml

--- a/cache-all.xq
+++ b/cache-all.xq
@@ -6,9 +6,10 @@ import module namespace aws_config = "http://history.state.gov/ns/xquery/aws_con
 import module namespace bucket = 'http://www.xquery.co.uk/modules/connectors/aws/s3/bucket' at 'modules/xaws/modules/uk/co/xquery/www/modules/connectors/aws-exist/s3/bucket.xq';
 
 declare namespace s3="http://s3.amazonaws.com/doc/2006-03-01/";
-declare namespace functx = "http://www.functx.com"; 
+declare namespace functx = "http://www.functx.com";
+import module namespace hsg-config = "http://history.state.gov/ns/xquery/config" at '/db/apps/hsg-shell/modules/config.xqm';
 
-declare variable $local:bucket := 'static.history.state.gov';
+declare variable $local:bucket := $hsg-config:S3_BUCKET;
 
 declare function functx:substring-after-last-match 
   ( $arg as xs:string? ,

--- a/load-cache-from-zip.xq
+++ b/load-cache-from-zip.xq
@@ -5,6 +5,7 @@ import module namespace unzip = "http://joewiz.org/ns/xquery/unzip" at "https://
 import module namespace http="http://expath.org/ns/http-client";
 import module namespace util="http://exist-db.org/xquery/util";
 import module namespace xmldb="http://exist-db.org/xquery/xmldb";
+import module namespace hsg-config = "http://history.state.gov/ns/xquery/config" at '/db/apps/hsg-shell/modules/config.xqm';
 
 (: the following module was copied from https://gist.github.com/joewiz/5938909 :)
 
@@ -75,7 +76,7 @@ declare function local:http-download($file-url as xs:string, $collection as xs:s
             <error><message>Oops, something went wrong:</message>{$head}</error>
 };
 
-let $url := 'https://s3.amazonaws.com/static.history.state.gov/temp/static.history.state.gov-ebooks-s3-cache.zip'
+let $url := $hsg-config:S3_URL || '/temp/static.history.state.gov-ebooks-s3-cache.zip'
 return
     try {
         let $collection := xmldb:create-collection('/db', 'hsg-temp')

--- a/test/bucket-list.xq
+++ b/test/bucket-list.xq
@@ -4,10 +4,11 @@ xquery version "3.1";
 
 import module namespace aws_config = "http://history.state.gov/ns/xquery/aws_config" at "/db/apps/s3/modules/aws_config.xqm";
 import module namespace bucket = "http://www.xquery.co.uk/modules/connectors/aws/s3/bucket" at "/db/apps/s3/modules/xaws/modules/uk/co/xquery/www/modules/connectors/aws-exist/s3/bucket.xq";
+import module namespace hsg-config = "http://history.state.gov/ns/xquery/config" at '/db/apps/hsg-shell/modules/config.xqm';
 
 let $aws-access-key := $aws_config:AWS-ACCESS-KEY
 let $aws-secret := $aws_config:AWS-SECRET-KEY
-let $bucket := "static.history.state.gov"
+let $bucket := $hsg-config:S3_BUCKET
 let $delimiter := "/"
 let $marker := ""
 let $max-keys := 10

--- a/test/object-delete.xq
+++ b/test/object-delete.xq
@@ -4,10 +4,11 @@ xquery version "3.1";
 
 import module namespace aws_config = "http://history.state.gov/ns/xquery/aws_config" at "/db/apps/s3/modules/aws_config.xqm";
 import module namespace object = "http://www.xquery.co.uk/modules/connectors/aws/s3/object" at "/db/apps/s3/modules/xaws/modules/uk/co/xquery/www/modules/connectors/aws-exist/s3/object.xq";
+import module namespace hsg-config = "http://history.state.gov/ns/xquery/config" at '/db/apps/hsg-shell/modules/config.xqm';
 
 let $aws-access-key := $aws_config:AWS-ACCESS-KEY
 let $aws-secret := $aws_config:AWS-SECRET-KEY
-let $bucket := "static.history.state.gov"
+let $bucket := $hsg-config:S3_BUCKET
 let $key := "temp/test.txt"
 let $content := "test"
 return

--- a/test/object-read.xq
+++ b/test/object-read.xq
@@ -4,10 +4,11 @@ xquery version "3.1";
 
 import module namespace aws_config = "http://history.state.gov/ns/xquery/aws_config" at "/db/apps/s3/modules/aws_config.xqm";
 import module namespace object = "http://www.xquery.co.uk/modules/connectors/aws/s3/object" at "/db/apps/s3/modules/xaws/modules/uk/co/xquery/www/modules/connectors/aws-exist/s3/object.xq";
+import module namespace hsg-config = "http://history.state.gov/ns/xquery/config" at '/db/apps/hsg-shell/modules/config.xqm';
 
 let $aws-access-key := $aws_config:AWS-ACCESS-KEY
 let $aws-secret := $aws_config:AWS-SECRET-KEY
-let $bucket := "static.history.state.gov"
+let $bucket := $hsg-config:S3_BUCKET
 let $key := "robots.txt"
 return
     (

--- a/test/object-write.xq
+++ b/test/object-write.xq
@@ -5,10 +5,11 @@ xquery version "3.1";
 import module namespace aws_config = "http://history.state.gov/ns/xquery/aws_config" at "/db/apps/s3/modules/aws_config.xqm";
 import module namespace object = "http://www.xquery.co.uk/modules/connectors/aws/s3/object" at "/db/apps/s3/modules/xaws/modules/uk/co/xquery/www/modules/connectors/aws-exist/s3/object.xq";
 import module namespace const = "http://www.xquery.co.uk/modules/connectors/aws/s3/constants" at "/db/apps/s3/modules/xaws/modules/uk/co/xquery/www/modules/connectors/aws-exist/s3/constants.xq";
+import module namespace hsg-config = "http://history.state.gov/ns/xquery/config" at '/db/apps/hsg-shell/modules/config.xqm';
 
 let $aws-access-key := $aws_config:AWS-ACCESS-KEY
 let $aws-secret := $aws_config:AWS-SECRET-KEY
-let $bucket := "static.history.state.gov"
+let $bucket := $hsg-config:S3_BUCKET
 return
     (
         object:write($aws-access-key, $aws-secret, $bucket, "temp/test.txt", "test"),


### PR DESCRIPTION
Import hsg-shell config and use constants $hsg-config:S3_BUCKET and
$hsg-config:S3_URL for paths to S3 buckets.

Note:  
There is a problematic path   
`'https://s3.amazonaws.com/static.history.state.gov/temp/static.history.state.gov-ebooks-s3-cache.zip'`  
in file `load-cache-from-zip.xq`,   
which I replaced with   
`let $url := $hsg-config:S3_URL || '/temp/static.history.state.gov-ebooks-s3-cache.zip'`.

The problematic part is the `static.history.state.gov-ebooks-s3-cache.zip'`:   
It seems, that this is the bucket name and a filename concatented with a dash, but it could also just be a filename and no bucketname. I left this uri as mentioned above for the time being and could refactor it later with a constant containing the current UAT / PROD S3 bucketname, if needed .