### PR TITLE
Fix(permissions): Remove guest access from aws_config_tmpl.xqm

### DIFF
--- a/post-install.xql
+++ b/post-install.xql
@@ -1,0 +1,18 @@
+xquery version "3.0";
+
+declare namespace repo="http://exist-db.org/xquery/repo";
+
+(: The following external variables are set by the repo:deploy function :)
+
+(: file path pointing to the exist installation directory :)
+declare variable $home external;
+(: path to the directory containing the unpacked .xar package :)
+declare variable $dir external;
+(: the target collection into which the app is deployed :)
+declare variable $target external;
+
+(:
+ : Module "aws_config_tmpl.xqm", which is the template file for module "aws_config.xqm"
+ : contains sensitive information, therefore we removed guest access to this file.
+ :)
+sm:chmod(xs:anyURI($target || "/modules/aws_config_tmpl.xqm"), "rwxrwx---")

--- a/repo.xml.tmpl
+++ b/repo.xml.tmpl
@@ -9,6 +9,7 @@
     <type>application</type>
     <target>s3</target>
     <prepare>pre-install.xql</prepare>
+    <finish>post-install.xql</finish>
     <finish/>
     <permissions password="" user="hsg" group="hsg" mode="rw-rw-r--"/>
 </meta>


### PR DESCRIPTION
Module "aws_config_tmpl.xqm", which is the template file for module "aws_config.xqm", contains sensitive information, therefore we removed guest access to this file.

**Important:** 
This change requires eXist-db 6.2.0.

---

This open source contribution to the S3 project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.